### PR TITLE
MCP-189067: Add remove-global-ember transform

### DIFF
--- a/.changeset/proud-eyes-vanish.md
+++ b/.changeset/proud-eyes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+feat: Add remove-global-ember transform

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npx @ciena-org/ember-codemods $TRANSFORM path/of/files/ or/some**/*glob.js
 | 3.27          | [argument-less-helper-paren-less-invocation](https://deprecations.emberjs.com/id/argument-less-helper-paren-less-invocation) | |
 | 3.27          | [deprecated-run-loop-and-computed-dot-access](https://deprecations.emberjs.com/id/deprecated-run-loop-and-computed-dot-access) | |
 | 3.27          | [ember.built-in-components.import](https://deprecations.emberjs.com/id/ember-built-in-components-import) | |
-| 3.27          | [ember-global](https://deprecations.emberjs.com/id/ember-global) | |
+| 3.27          | [ember-global](https://deprecations.emberjs.com/id/ember-global) | [remove-global-ember](./src/transforms/remove-global-ember/) |
 | 4.0           | [ember-polyfills.deprecate-assign](https://deprecations.emberjs.com/id/ember-polyfills-deprecate-assign) | |
 | 4.1           | [deprecate-auto-location](https://deprecations.emberjs.com/id/deprecate-auto-location) | |
 | 4.10          | [deprecate-ember-error](https://deprecations.emberjs.com/id/deprecate-ember-error) | revert-ember-error |

--- a/src/transforms/remove-global-ember/index.ts
+++ b/src/transforms/remove-global-ember/index.ts
@@ -1,0 +1,45 @@
+import type { API, FileInfo } from 'jscodeshift'
+import {Options} from "jscodeshift";
+
+export const parser = 'ts'
+
+export default function transformer(fileInfo: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift
+
+  // Get the root of the current file's AST
+  const root = j(fileInfo.source, options)
+
+  const emberDefaultUsages = root.find(j.Identifier).filter(path => path.value.name === 'Ember')
+
+  const emberImports = root.find(j.ImportDeclaration).filter(path => path.value.source.value === 'ember')
+
+  const hasDefaultEmberImport = emberImports.find(j.ImportDefaultSpecifier).some(path => path.value.local?.name === 'Ember')
+
+  if (emberDefaultUsages.length > 0 && !hasDefaultEmberImport) {
+    const emberImportDefaultSpecifier = j.importDefaultSpecifier(j.identifier('Ember'))
+
+    if (emberImports.length > 0) {
+      const firstImport = emberImports.at(0)
+
+      firstImport.replaceWith(path => {
+        return j.importDeclaration([emberImportDefaultSpecifier, ...(path.value.specifiers ?? [])], path.value.source)
+      })
+    } else {
+      const defaultEmberImport = j.importDeclaration([emberImportDefaultSpecifier], j.literal('ember'))
+
+      const allImports = root.find(j.ImportDeclaration)
+
+      if (allImports.length) {
+        const lastImport = allImports.at(-1)
+
+        lastImport.insertAfter(defaultEmberImport)
+      } else {
+        // Insert ember import at the top of the file if there are no imports
+        root.find(j.Program).replaceWith(programNode => j.program([defaultEmberImport, ...programNode.value.body]))
+      }
+    }
+  }
+
+  // Return the modified code
+  return root.toSource({ quote: 'single', objectCurlySpacing: false })
+}

--- a/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.input.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.input.js
@@ -1,0 +1,12 @@
+import {other} from 'ember';
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting () {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.input.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.input.ts
@@ -1,0 +1,12 @@
+import {other} from 'ember';
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting (): boolean {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.output.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.output.js
@@ -1,0 +1,12 @@
+import Ember, {other} from 'ember';
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting () {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.output.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/has-ember-imports.output.ts
@@ -1,0 +1,12 @@
+import Ember, {other} from 'ember';
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting (): boolean {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-change.input.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-change.input.js
@@ -1,0 +1,12 @@
+import Ember, {other} from 'ember'
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting () {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-change.input.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-change.input.ts
@@ -1,0 +1,12 @@
+import Ember, {other} from 'ember'
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting (): boolean {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-change.output.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-change.output.js
@@ -1,0 +1,12 @@
+import Ember, {other} from 'ember'
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting () {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-change.output.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-change.output.ts
@@ -1,0 +1,12 @@
+import Ember, {other} from 'ember'
+import {something} from 'ember'
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting (): boolean {
+    return testing && other && something
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.input.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.input.js
@@ -1,0 +1,10 @@
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting () {
+    return testing
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.input.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.input.ts
@@ -1,0 +1,10 @@
+import {Component} from 'frost-core-components'
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting (): boolean {
+    return testing
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.output.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.output.js
@@ -1,0 +1,12 @@
+import {Component} from 'frost-core-components'
+
+import Ember from 'ember';
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting () {
+    return testing
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.output.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-ember-imports.output.ts
@@ -1,0 +1,12 @@
+import {Component} from 'frost-core-components'
+
+import Ember from 'ember';
+
+const {testing} = Ember
+
+export default Component.extend({
+  // == Functions =============================================================
+  getTesting (): boolean {
+    return testing
+  }
+})

--- a/src/transforms/remove-global-ember/tests/fixtures/no-imports.input.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-imports.input.js
@@ -1,0 +1,9 @@
+export function getComponent () {
+  return Ember.Component()
+}
+
+export function getTesting () {
+  const {testing} = Ember
+
+  return testing
+}

--- a/src/transforms/remove-global-ember/tests/fixtures/no-imports.input.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-imports.input.ts
@@ -1,0 +1,9 @@
+export function getComponent (): any {
+  return Ember.Component()
+}
+
+export function getTesting (): boolean {
+  const {testing} = Ember
+
+  return testing
+}

--- a/src/transforms/remove-global-ember/tests/fixtures/no-imports.output.js
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-imports.output.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+export function getComponent () {
+  return Ember.Component()
+}
+
+export function getTesting () {
+  const {testing} = Ember
+
+  return testing
+}

--- a/src/transforms/remove-global-ember/tests/fixtures/no-imports.output.ts
+++ b/src/transforms/remove-global-ember/tests/fixtures/no-imports.output.ts
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+export function getComponent (): any {
+  return Ember.Component()
+}
+
+export function getTesting (): boolean {
+  const {testing} = Ember
+
+  return testing
+}

--- a/src/transforms/remove-global-ember/tests/transform.test.ts
+++ b/src/transforms/remove-global-ember/tests/transform.test.ts
@@ -1,0 +1,47 @@
+import runTestCases from '#utils/testHelper.js'
+import transform, {parser} from '#transforms/remove-global-ember/index.js'
+
+const testCases = [
+  {
+    name: 'should handle global Ember usage with no other ember imports in javascript',
+    input: 'no-ember-imports.input.js',
+    output: 'no-ember-imports.output.js'
+  },
+  {
+    name: 'should handle global Ember usage with no other ember imports in typescript',
+    input: 'no-ember-imports.input.ts',
+    output: 'no-ember-imports.output.ts'
+  },
+  {
+    name: 'should handle global Ember usage with other ember imports in javascript',
+    input: 'has-ember-imports.input.js',
+    output: 'has-ember-imports.output.js'
+  },
+  {
+    name: 'should handle global Ember usage with other ember imports in typescript',
+    input: 'has-ember-imports.input.ts',
+    output: 'has-ember-imports.output.ts'
+  },
+  {
+    name: 'should handle global Ember usage with no other imports in javascript',
+    input: 'no-imports.input.js',
+    output: 'no-imports.output.js'
+  },
+  {
+    name: 'should handle global Ember usage with no other imports in typescript',
+    input: 'no-imports.input.ts',
+    output: 'no-imports.output.ts'
+  },
+  {
+    name: 'should not do anything if Ember is imported properly in javascript',
+    input: 'no-change.input.js',
+    output: 'no-change.output.js'
+  },
+  {
+    name: 'should not do anything if Ember is imported properly in typescript',
+    input: 'no-change.input.js',
+    output: 'no-change.output.js'
+  }
+]
+
+runTestCases('remove-global-ember', __dirname, testCases, transform, parser)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "customConditions": ["ciena-org-ember-codemods-dev"]
-  }
+  },
+  "exclude" : [
+    "**/tests/fixtures/*"
+  ]
 }


### PR DESCRIPTION
Add the remove-global-ember transform to address the [ember-global](https://deprecations.emberjs.com/id/ember-global) deprecation.