### PR TITLE
built-in-components-import and remove-run-loop-and-computed-dot-access

### DIFF
--- a/.changeset/hot-pumpkins-chew.md
+++ b/.changeset/hot-pumpkins-chew.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+feat: Add remove-run-loop-and-computed-dot-access transform to address Run loop and computed dot access deprecation

--- a/.changeset/tricky-gifts-juggle.md
+++ b/.changeset/tricky-gifts-juggle.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Add built-in-components-import transform for handling legacy built in template imports

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ npx @ciena-org/ember-codemods $TRANSFORM path/of/files/ or/some**/*glob.js
 | 3.26          | [ember-glimmer.with-syntax](https://deprecations.emberjs.com/id/ember-glimmer-with-syntax) | |
 | 3.26          | [has-block-and-has-block-params](https://deprecations.emberjs.com/id/has-block-and-has-block-params) | [has-block](./src/transforms/has-block/) |
 | 3.27          | [argument-less-helper-paren-less-invocation](https://deprecations.emberjs.com/id/argument-less-helper-paren-less-invocation) | |
-| 3.27          | [deprecated-run-loop-and-computed-dot-access](https://deprecations.emberjs.com/id/deprecated-run-loop-and-computed-dot-access) | |
-| 3.27          | [ember.built-in-components.import](https://deprecations.emberjs.com/id/ember-built-in-components-import) | |
+| 3.27          | [deprecated-run-loop-and-computed-dot-access](https://deprecations.emberjs.com/id/deprecated-run-loop-and-computed-dot-access) | [remove-run-loop-and-computed-dot-access](./src/transforms/remove-run-loop-and-computed-dot-access/)|
+| 3.27          | [ember.built-in-components.import](https://deprecations.emberjs.com/id/ember-built-in-components-import) | [built-in-components-import](./src/transforms/built-in-components-import/)|
 | 3.27          | [ember-global](https://deprecations.emberjs.com/id/ember-global) | [remove-global-ember](./src/transforms/remove-global-ember/) |
 | 4.0           | [ember-polyfills.deprecate-assign](https://deprecations.emberjs.com/id/ember-polyfills-deprecate-assign) | |
 | 4.1           | [deprecate-auto-location](https://deprecations.emberjs.com/id/deprecate-auto-location) | |

--- a/src/transforms/built-in-components-import/index.ts
+++ b/src/transforms/built-in-components-import/index.ts
@@ -1,0 +1,38 @@
+import { API, FileInfo, JSCodeshift, Options } from "jscodeshift";
+
+export const parser = "ts";
+
+const LEGACY_COMPONENTS = {
+  "@ember/component/checkbox": "Checkbox",
+  "@ember/routing/link-component": "LinkComponent",
+  "@ember/component/text-area": "TextArea",
+  "@ember/component/text-field": "TextField",
+};
+
+export default function transformer(
+  file: FileInfo,
+  api: API,
+  options: Options,
+) {
+  const j: JSCodeshift = api.jscodeshift;
+  const root = j(file.source, options);
+
+  //Analyse import statements if @ember/component/xx components are imported
+  root.find(j.ImportDeclaration).forEach((path) => {
+    const importSource = path.node.source.value;
+    if (typeof importSource === "string") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const legacyComponent = (LEGACY_COMPONENTS as any)[importSource];
+      if (legacyComponent) {
+        const newImport = j.importDeclaration(
+          [j.importSpecifier(j.identifier(legacyComponent))],
+          j.literal("@ember/legacy-built-in-components"),
+        );
+
+        j(path).replaceWith(newImport);
+      }
+    }
+  });
+
+  return root.toSource({ quote: "single", objectCurlySpacing: false });
+}

--- a/src/transforms/built-in-components-import/tests/fixtures/transform.input.js
+++ b/src/transforms/built-in-components-import/tests/fixtures/transform.input.js
@@ -1,0 +1,5 @@
+import TextArea from '@ember/component/text-area';
+import {HookMixin} from 'ember-hook';
+
+export default TextArea.extend(HookMixin, {
+});

--- a/src/transforms/built-in-components-import/tests/fixtures/transform.input.ts
+++ b/src/transforms/built-in-components-import/tests/fixtures/transform.input.ts
@@ -1,0 +1,5 @@
+import TextField from '@ember/component/text-field';
+import {HookMixin} from 'ember-hook';
+
+export default TextField.extend(HookMixin, {
+});

--- a/src/transforms/built-in-components-import/tests/fixtures/transform.output.js
+++ b/src/transforms/built-in-components-import/tests/fixtures/transform.output.js
@@ -1,0 +1,5 @@
+import {TextArea} from '@ember/legacy-built-in-components';
+import {HookMixin} from 'ember-hook';
+
+export default TextArea.extend(HookMixin, {
+});

--- a/src/transforms/built-in-components-import/tests/fixtures/transform.output.ts
+++ b/src/transforms/built-in-components-import/tests/fixtures/transform.output.ts
@@ -1,0 +1,5 @@
+import {TextField} from '@ember/legacy-built-in-components';
+import {HookMixin} from 'ember-hook';
+
+export default TextField.extend(HookMixin, {
+});

--- a/src/transforms/built-in-components-import/tests/transform.test.ts
+++ b/src/transforms/built-in-components-import/tests/transform.test.ts
@@ -1,0 +1,25 @@
+import runTestCases from "#utils/testHelper.js";
+import transform, {
+  parser,
+} from "#transforms/built-in-components-import/index.js";
+
+const testCases = [
+  {
+    name: "should handle built-in-components-import in javascript",
+    input: "transform.input.js",
+    output: "transform.output.js",
+  },
+  {
+    name: "should handle built-in-components-import in typescript",
+    input: "transform.input.ts",
+    output: "transform.output.ts",
+  },
+];
+
+runTestCases(
+  "built-in-components-import",
+  __dirname,
+  testCases,
+  transform,
+  parser,
+);

--- a/src/transforms/remove-run-loop-and-computed-dot-access/index.ts
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/index.ts
@@ -1,0 +1,164 @@
+import {
+  API,
+  FileInfo,
+  ImportDeclaration,
+  JSCodeshift,
+  Options,
+} from "jscodeshift";
+
+export const parser = "ts";
+
+const COMPUTED_METHODS = new Set([
+  "alias",
+  "and",
+  "bool",
+  "collect",
+  "deprecatingAlias",
+  "empty",
+  "equal",
+  "filterBy",
+  "filter",
+  "gte",
+  "gt",
+  "intersect",
+  "lte",
+  "lt",
+  "mapBy",
+  "map",
+  "match",
+  "max",
+  "min",
+  "none",
+  "notEmpty",
+  "not",
+  "oneWay",
+  "or",
+  "readOnly",
+  "setDiff",
+  "sort",
+  "sum",
+  "union",
+  "uniqBy",
+  "uniq",
+]);
+
+const RUN_METHODS = new Set([
+  "backburner",
+  "begin",
+  "bind",
+  "cancel",
+  "debounce",
+  "end",
+  "hasScheduledTimers",
+  "join",
+  "later",
+  "next",
+  "once",
+  "schedule",
+  "scheduleOnce",
+  "throttle",
+  "cancelTimers",
+]);
+
+export default function transformer(
+  file: FileInfo,
+  api: API,
+  options: Options,
+) {
+  const j: JSCodeshift = api.jscodeshift;
+  const root = j(file.source, options);
+
+  const computedImports = new Set<string>();
+  const runImports = new Set<string>();
+  let hasComputedUsage = false;
+  let hasRunUsage = false;
+
+  // check for computed.method usage
+  root
+    .find(j.MemberExpression, {
+      object: { type: "Identifier", name: "computed" },
+      property: { type: "Identifier" },
+    })
+    .forEach((path) => {
+      const value = path.value;
+      if (
+        j.Identifier.check(value.object) &&
+        j.Identifier.check(value.property)
+      ) {
+        const methodName = value.property.name;
+        if (COMPUTED_METHODS.has(methodName)) {
+          hasComputedUsage = true;
+          computedImports.add(methodName);
+          j(path).replaceWith(j.identifier(methodName));
+        }
+      }
+    });
+
+  // check for run.method usage
+  root
+    .find(j.MemberExpression, {
+      object: { type: "Identifier", name: "run" },
+      property: { type: "Identifier" },
+    })
+    .forEach((path) => {
+      const value = path.value;
+      if (
+        j.Identifier.check(value.object) &&
+        j.Identifier.check(value.property)
+      ) {
+        const methodName = value.property.name;
+        if (RUN_METHODS.has(methodName)) {
+          hasRunUsage = true;
+          runImports.add(methodName);
+          j(path).replaceWith(j.identifier(methodName));
+        }
+      }
+    });
+
+  if (hasComputedUsage || hasRunUsage) {
+    // Remove existing comuted/run imports
+    root.find(j.ImportDeclaration).forEach((path) => {
+      const node = path.value as ImportDeclaration;
+      if (node.source.value === "@ember/object") {
+        node.specifiers = node.specifiers?.filter(
+          (spec) =>
+            spec.type === "ImportSpecifier" &&
+            spec.imported.name !== "computed",
+        );
+      }
+      if (node.source.value === "@ember/runloop") {
+        node.specifiers = node.specifiers?.filter(
+          (spec) =>
+            spec.type === "ImportSpecifier" && spec.imported.name !== "run",
+        );
+      }
+
+      if (node.specifiers?.length === 0) {
+        j(path).remove();
+      }
+    });
+
+    //Insert new imports
+    if (runImports.size > 0) {
+      const newRunImport = j.importDeclaration(
+        Array.from(runImports).map((method) =>
+          j.importSpecifier(j.identifier(method)),
+        ),
+        j.literal("@ember/runloop"),
+      );
+      root.get().node.program.body.unshift(newRunImport);
+    }
+
+    if (computedImports.size > 0) {
+      const newComutedImports = j.importDeclaration(
+        Array.from(computedImports).map((method) =>
+          j.importSpecifier(j.identifier(method)),
+        ),
+        j.literal("@ember/object/computed"),
+      );
+      root.get().node.program.body.unshift(newComutedImports);
+    }
+  }
+
+  return root.toSource({ quote: "single", objectCurlySpacing: false });
+}

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/import.input.js
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/import.input.js
@@ -1,0 +1,5 @@
+import {computed, set} from '@ember/object';
+
+const sortedItems = computed.sort('items', 'sortConfig');
+const foo = computed.or('isRadiusUserSelected', 'isTacacsPlusUserSelected');
+set(this, 'bar', 'baz');

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/import.output.js
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/import.output.js
@@ -1,0 +1,6 @@
+import {sort, or} from '@ember/object/computed';
+import {set} from '@ember/object';
+
+const sortedItems = sort('items', 'sortConfig');
+const foo = or('isRadiusUserSelected', 'isTacacsPlusUserSelected');
+set(this, 'bar', 'baz');

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.input.js
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.input.js
@@ -1,5 +1,5 @@
-import {run} from '@ember/runloop';
 import {computed} from '@ember/object';
+import {run} from '@ember/runloop';
 
 const sortedItems = computed.sort('items', 'sortConfig');
 const foo = computed.or('isRadiusUserSelected', 'isTacacsPlusUserSelected');

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.input.js
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.input.js
@@ -1,0 +1,9 @@
+import {run} from '@ember/runloop';
+import {computed} from '@ember/object';
+
+const sortedItems = computed.sort('items', 'sortConfig');
+const foo = computed.or('isRadiusUserSelected', 'isTacacsPlusUserSelected');
+
+run.later(() => {
+  this.someValue = false
+}, 100);

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.input.ts
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.input.ts
@@ -1,0 +1,6 @@
+import {run} from '@ember/runloop';
+
+run.once(this, 'draw')
+run.next(() =>
+  doSomething()
+)

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.output.js
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.output.js
@@ -1,5 +1,5 @@
-import {later} from '@ember/runloop';
 import {sort, or} from '@ember/object/computed';
+import {later} from '@ember/runloop';
 
 const sortedItems = sort('items', 'sortConfig');
 const foo = or('isRadiusUserSelected', 'isTacacsPlusUserSelected');

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.output.js
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.output.js
@@ -1,0 +1,9 @@
+import {later} from '@ember/runloop';
+import {sort, or} from '@ember/object/computed';
+
+const sortedItems = sort('items', 'sortConfig');
+const foo = or('isRadiusUserSelected', 'isTacacsPlusUserSelected');
+
+later(() => {
+  this.someValue = false
+}, 100);

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.output.ts
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/fixtures/transform.output.ts
@@ -1,0 +1,6 @@
+import {once, next} from '@ember/runloop';
+
+once(this, 'draw')
+next(() =>
+  doSomething()
+)

--- a/src/transforms/remove-run-loop-and-computed-dot-access/tests/transform.test.ts
+++ b/src/transforms/remove-run-loop-and-computed-dot-access/tests/transform.test.ts
@@ -1,0 +1,30 @@
+import runTestCases from "#utils/testHelper.js";
+import transform, {
+  parser,
+} from "#transforms/remove-run-loop-and-computed-dot-access/index.js";
+
+const testCases = [
+  {
+    name: "should handle run loop and computed imports dot access in javascript",
+    input: "transform.input.js",
+    output: "transform.output.js",
+  },
+  {
+    name: "should handle run loop and computed imports in ts",
+    input: "transform.input.ts",
+    output: "transform.output.ts",
+  },
+  {
+    name: "should handle run loop and computed imports with other imports",
+    input: "import.input.js",
+    output: "import.output.js",
+  },
+];
+
+runTestCases(
+  "remove-run-loop-and-computed-dot-access",
+  __dirname,
+  testCases,
+  transform,
+  parser,
+);


### PR DESCRIPTION
Added transforms for :
[built-in-components-import](https://deprecations.emberjs.com/id/ember-built-in-components-import)
[remove-run-loop-and-computed-dot-access](https://deprecations.emberjs.com/id/deprecated-run-loop-and-computed-dot-access)