### PR TITLE
MCP-189061: Add replace-with-syntax transform

### DIFF
--- a/.changeset/nasty-snakes-cross.md
+++ b/.changeset/nasty-snakes-cross.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Add replace-with-syntax transform to address `ember-glimmer.with-syntax` deprecation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ npx @ciena-org/ember-codemods $TRANSFORM path/of/files/ or/some**/*glob.js
 | 3.26          | [ember-glimmer.link-to-positional-arguments](https://deprecations.emberjs.com/id/ember-glimmer-link-to-positional-arguments) | [link-to-positional](./src/transforms/link-to-positional) |
 | 3.26          | [ember-glimmer.with-syntax](https://deprecations.emberjs.com/id/ember-glimmer-with-syntax) | [replace-with-styntax](./src/transforms/replace-with-syntax/) |
 | 3.26          | [has-block-and-has-block-params](https://deprecations.emberjs.com/id/has-block-and-has-block-params) | [has-block](./src/transforms/has-block/) |
-| 3.27          | [argument-less-helper-paren-less-invocation](https://deprecations.emberjs.com/id/argument-less-helper-paren-less-invocation) | |
 | 3.27          | [deprecated-run-loop-and-computed-dot-access](https://deprecations.emberjs.com/id/deprecated-run-loop-and-computed-dot-access) | [remove-run-loop-and-computed-dot-access](./src/transforms/remove-run-loop-and-computed-dot-access/)|
 | 3.27          | [ember.built-in-components.import](https://deprecations.emberjs.com/id/ember-built-in-components-import) | [built-in-components-import](./src/transforms/built-in-components-import/)|
 | 3.27          | [ember-global](https://deprecations.emberjs.com/id/ember-global) | [remove-global-ember](./src/transforms/remove-global-ember/) |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx @ciena-org/ember-codemods $TRANSFORM path/of/files/ or/some**/*glob.js
 | 3.24          | [ember-string.prototype-extensions](https://deprecations.emberjs.com/id/ember-string-prototype-extensions)  | [ember-string-codemod](./src/transforms/ember-string-codemod/) |
 | 3.25          | [ember-string.htmlsafe-ishtmlsafe](https://deprecations.emberjs.com/id/ember-string-htmlsafe-ishtmlsafe) | [ember-string-htmlsafe-ishtmlsafe](./src/transforms/ember-string-htmlsafe-ishtmlsafe/) |
 | 3.26          | [ember-glimmer.link-to-positional-arguments](https://deprecations.emberjs.com/id/ember-glimmer-link-to-positional-arguments) | [link-to-positional](./src/transforms/link-to-positional) |
-| 3.26          | [ember-glimmer.with-syntax](https://deprecations.emberjs.com/id/ember-glimmer-with-syntax) | |
+| 3.26          | [ember-glimmer.with-syntax](https://deprecations.emberjs.com/id/ember-glimmer-with-syntax) | [replace-with-styntax](./src/transforms/replace-with-syntax/) |
 | 3.26          | [has-block-and-has-block-params](https://deprecations.emberjs.com/id/has-block-and-has-block-params) | [has-block](./src/transforms/has-block/) |
 | 3.27          | [argument-less-helper-paren-less-invocation](https://deprecations.emberjs.com/id/argument-less-helper-paren-less-invocation) | |
 | 3.27          | [deprecated-run-loop-and-computed-dot-access](https://deprecations.emberjs.com/id/deprecated-run-loop-and-computed-dot-access) | [remove-run-loop-and-computed-dot-access](./src/transforms/remove-run-loop-and-computed-dot-access/)|

--- a/src/transforms/replace-with-syntax/index.ts
+++ b/src/transforms/replace-with-syntax/index.ts
@@ -1,0 +1,48 @@
+import type { FileInfo } from "jscodeshift";
+import { transform, TransformPluginBuilder } from "ember-template-recast";
+
+export const parser = "ts";
+
+const replaceWithSyntaxTransformPlugin: TransformPluginBuilder = (env) => {
+  const {
+    syntax: { builders },
+  } = env;
+
+  return {
+    BlockStatement(node) {
+      if (
+        node.path.type === "PathExpression" &&
+        node.path.original === "with"
+      ) {
+        const param = node.params[0];
+        if (param?.type === "PathExpression") {
+          return builders.block(
+            builders.path("let"),
+            node.params,
+            builders.hash(),
+            builders.program(
+              [
+                builders.text("\n"),
+                builders.block(
+                  builders.path("if"),
+                  node.program.blockParams.map((param) => builders.path(param)),
+                  builders.hash(),
+                  builders.program(node.program.body),
+                  node.inverse,
+                ),
+                builders.text("\n"),
+              ],
+              node.program.blockParams,
+            ),
+          );
+        } else {
+          return { ...node, path: builders.path("let") };
+        }
+      }
+    },
+  };
+};
+
+export default function transformer(fileInfo: FileInfo) {
+  return transform(fileInfo.source, replaceWithSyntaxTransformPlugin).code;
+}

--- a/src/transforms/replace-with-syntax/tests/fixtures/no-change.input.hbs
+++ b/src/transforms/replace-with-syntax/tests/fixtures/no-change.input.hbs
@@ -1,0 +1,15 @@
+{{#let (hash name="Ben" age=4) as |person|}}
+  Hi {{person.name}}, you are {{person.age}} years old.
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{/if}}
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{else}}
+  There are no blog posts
+{{/if}}
+{{/let}}

--- a/src/transforms/replace-with-syntax/tests/fixtures/no-change.output.hbs
+++ b/src/transforms/replace-with-syntax/tests/fixtures/no-change.output.hbs
@@ -1,0 +1,15 @@
+{{#let (hash name="Ben" age=4) as |person|}}
+  Hi {{person.name}}, you are {{person.age}} years old.
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{/if}}
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{else}}
+  There are no blog posts
+{{/if}}
+{{/let}}

--- a/src/transforms/replace-with-syntax/tests/fixtures/transform.input.hbs
+++ b/src/transforms/replace-with-syntax/tests/fixtures/transform.input.hbs
@@ -1,0 +1,15 @@
+{{#let (hash name="Ben" age=4) as |person|}}
+  Hi {{person.name}}, you are {{person.age}} years old.
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{/if}}
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{else}}
+  There are no blog posts
+{{/if}}
+{{/let}}

--- a/src/transforms/replace-with-syntax/tests/fixtures/transform.output.hbs
+++ b/src/transforms/replace-with-syntax/tests/fixtures/transform.output.hbs
@@ -1,0 +1,15 @@
+{{#let (hash name="Ben" age=4) as |person|}}
+  Hi {{person.name}}, you are {{person.age}} years old.
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{/if}}
+{{/let}}
+{{#let user.posts as |blogPosts|}}
+{{#if blogPosts}}
+  There are {{blogPosts.length}} blog posts
+{{else}}
+  There are no blog posts
+{{/if}}
+{{/let}}

--- a/src/transforms/replace-with-syntax/tests/transform.test.ts
+++ b/src/transforms/replace-with-syntax/tests/transform.test.ts
@@ -1,0 +1,17 @@
+import runTestCases from "#utils/testHelper.js";
+import transform, { parser } from "#transforms/replace-with-syntax/index.js";
+
+const testCases = [
+  {
+    name: "should handle `#with` syntax usage",
+    input: "transform.input.hbs",
+    output: "transform.output.hbs",
+  },
+  {
+    name: "should not do anything if there is no `#with` syntax usage",
+    input: "no-change.input.hbs",
+    output: "no-change.output.hbs",
+  },
+];
+
+runTestCases("replace-with-syntax", __dirname, testCases, transform, parser);


### PR DESCRIPTION
* Also remove unnecessary argument-less-helper-paren-less-invocation transform row from README
  * This codemod actually shouldn't be needed since the no-implicit-this
  eslint rule should catch any instances and it'll require manual
  consideration about whether it was a component prop that was missed or
  it's actually a helper that has no arguments.