### PR TITLE
Disable string prototype config with ember-string-codemod transform

### DIFF
--- a/.changeset/twelve-walls-rhyme.md
+++ b/.changeset/twelve-walls-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Disable string prototype config with ember-string-codemod transform

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-has-string-proto/config/environment.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-has-string-proto/config/environment.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {
+    EmberENV: {
+      FEATURES: {},
+      EXTEND_PROTOTYPES: {
+        String: true,
+        Date: false
+      }
+    }
+  }
+
+  return ENV
+}

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-has-string-proto/config/environment.output.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-has-string-proto/config/environment.output.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {
+    EmberENV: {
+      FEATURES: {},
+      EXTEND_PROTOTYPES: {
+        String: false,
+        Date: false
+      }
+    }
+  }
+
+  return ENV
+}

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-ember-env/config/environment.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-ember-env/config/environment.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {}
+
+  return ENV
+}
+

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-ember-env/config/environment.output.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-ember-env/config/environment.output.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {
+    EmberENV: {
+      EXTEND_PROTOTYPES: {
+        String: false
+      }
+    }
+  }
+
+  return ENV
+}
+

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-env/config/environment.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-env/config/environment.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = function (environment) {
+  return {}
+}
+

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-env/config/environment.output.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-env/config/environment.output.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = function (environment) {
+  return {}
+}
+

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-extend-proto/config/environment.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-extend-proto/config/environment.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {
+    EmberENV: {
+      FEATURES: {}
+    }
+  }
+
+  return ENV
+}

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-extend-proto/config/environment.output.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-extend-proto/config/environment.output.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {
+    EmberENV: {
+      FEATURES: {},
+
+      EXTEND_PROTOTYPES: {
+        String: false
+      }
+    }
+  }
+
+  return ENV
+}
+

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-string-proto/config/environment.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-string-proto/config/environment.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {
+    EmberENV: {
+      FEATURES: {},
+      EXTEND_PROTOTYPES: {
+        Date: false
+      }
+    }
+  }
+
+  return ENV
+}

--- a/src/transforms/ember-string-codemod/tests/fixtures/config-no-string-proto/config/environment.output.js
+++ b/src/transforms/ember-string-codemod/tests/fixtures/config-no-string-proto/config/environment.output.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = function (environment) {
+  const ENV = {
+    EmberENV: {
+      FEATURES: {},
+      EXTEND_PROTOTYPES: {
+        Date: false,
+        String: false
+      }
+    }
+  }
+
+  return ENV
+}

--- a/src/transforms/ember-string-codemod/tests/transform.test.ts
+++ b/src/transforms/ember-string-codemod/tests/transform.test.ts
@@ -17,6 +17,31 @@ const testCases = [
     input: "transform.input.ts",
     output: "transform.output.ts",
   },
+  {
+    name: "should handle config without environment configs",
+    input: "config-no-env/config/environment.js",
+    output: "config-no-env/config/environment.output.js",
+  },
+  {
+    name: "should handle config without EmberENV configs",
+    input: "config-no-ember-env/config/environment.js",
+    output: "config-no-ember-env/config/environment.output.js",
+  },
+  {
+    name: "should handle config without extended prototype configs",
+    input: "config-no-extend-proto/config/environment.js",
+    output: "config-no-extend-proto/config/environment.output.js",
+  },
+  {
+    name: "should handle config without string prototype configs",
+    input: "config-no-string-proto/config/environment.js",
+    output: "config-no-string-proto/config/environment.output.js",
+  },
+  {
+    name: "should handle config with string prototype configs",
+    input: "config-has-string-proto/config/environment.js",
+    output: "config-has-string-proto/config/environment.output.js",
+  },
 ];
 
 runTestCases("ember-string-codemod", __dirname, testCases, transform, parser);


### PR DESCRIPTION
* The string prototype extension config should be disabled as well when the `ember-string-codemod` transform is used to make sure no new usages of the deprecation are added