### PR TITLE
`link-to-positional` transform fixes

### DIFF
--- a/.changeset/modern-beds-provide.md
+++ b/.changeset/modern-beds-provide.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Add support for non-string routes and non-positional routes to link-to-positional transform

--- a/.changeset/modern-keys-serve.md
+++ b/.changeset/modern-keys-serve.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Fix attributes being removed by `link-to-positional` transform

--- a/src/transforms/link-to-positional/index.ts
+++ b/src/transforms/link-to-positional/index.ts
@@ -64,6 +64,25 @@ function getLinkToElement({
       );
     }
 
+    node.hash.pairs.forEach(({ key, value: node }) => {
+      switch (node.type) {
+        case "StringLiteral":
+          elementAttrs.push(builders.attr(key, builders.text(node.value)));
+          break;
+        case "SubExpression":
+          elementAttrs.push(
+            builders.attr(
+              key,
+              builders.mustache(node.path, node.params, node.hash),
+            ),
+          );
+          break;
+        default:
+          elementAttrs.push(builders.attr(key, builders.mustache(node)));
+          break;
+      }
+    });
+
     return builders.element("LinkTo", {
       attrs: elementAttrs,
       children: linkText

--- a/src/transforms/link-to-positional/tests/fixtures/transform.input.hbs
+++ b/src/transforms/link-to-positional/tests/fixtures/transform.input.hbs
@@ -11,3 +11,9 @@
 {{#link-to "posts" (query-params direction="desc" showArchived=false)}}
   Recent Posts
 {{/link-to}}
+{{#link-to "posts" class="foo"}}
+  Recent Posts
+{{/link-to}}
+{{#link-to "posts" @comment.post @comment (query-params direction="desc" showArchived=false) class="foo"}}
+  Recent Posts
+{{/link-to}}

--- a/src/transforms/link-to-positional/tests/fixtures/transform.input.hbs
+++ b/src/transforms/link-to-positional/tests/fixtures/transform.input.hbs
@@ -1,5 +1,17 @@
 {{link-to "About Us" "about"}}
+{{link-to "About Us" route="about"}}
+{{link-to "About Us" @post.title}}
+{{link-to "About Us" route=@post.title}}
 {{#link-to "about"}}
+  About Us
+{{/link-to}}
+{{#link-to route="about"}}
+  About Us
+{{/link-to}}
+{{#link-to @post.title}}
+  About Us
+{{/link-to}}
+{{#link-to route=@post.title}}
   About Us
 {{/link-to}}
 {{#link-to "post" @post}}

--- a/src/transforms/link-to-positional/tests/fixtures/transform.output.hbs
+++ b/src/transforms/link-to-positional/tests/fixtures/transform.output.hbs
@@ -11,3 +11,9 @@
 <LinkTo @route="posts" @query={{hash direction="desc" showArchived=false}}>
   Recent Posts
 </LinkTo>
+<LinkTo @route="posts" class="foo">
+  Recent Posts
+</LinkTo>
+<LinkTo @route="posts" @models={{array @comment.post @comment}} @query={{hash direction="desc" showArchived=false}} class="foo">
+  Recent Posts
+</LinkTo>

--- a/src/transforms/link-to-positional/tests/fixtures/transform.output.hbs
+++ b/src/transforms/link-to-positional/tests/fixtures/transform.output.hbs
@@ -1,5 +1,17 @@
 <LinkTo @route="about">About Us</LinkTo>
+<LinkTo @route="about">About Us</LinkTo>
+<LinkTo @route={{@post.title}}>About Us</LinkTo>
+<LinkTo @route={{@post.title}}>About Us</LinkTo>
 <LinkTo @route="about">
+  About Us
+</LinkTo>
+<LinkTo @route="about">
+  About Us
+</LinkTo>
+<LinkTo @route={{@post.title}}>
+  About Us
+</LinkTo>
+<LinkTo @route={{@post.title}}>
   About Us
 </LinkTo>
 <LinkTo @route="post" @model={{@post}}>


### PR DESCRIPTION
* Fix attributes being removed by transform
* Add support for non-string routes and non-positional routes