### PR TITLE
Add `ember-code-snippets-helper` transform

### DIFF
--- a/.changeset/two-games-punch.md
+++ b/.changeset/two-games-punch.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Add `ember-code-snippets-helper` transform that can be used when updating `ember-code-snippets` to v3

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npx @ciena-org/ember-codemods $TRANSFORM path/of/files/ or/some**/*glob.js
 | Transform | Description | Possible issues |
 | --------- | ----------- | --------------- |
 | [revert-computed-macro](./src/transforms/revert-computed-macro/)| Replace `computed` from `ember-macro-helpers` with `@ember/object` instead. | <ul><li>Will add variable even if not used from function before. Can just remove as need be (or PR fix), was not a common occurence in my code to have unused dependency</li></ul> |
+| [ember-code-snippets-helper](./src/transforms/ember-code-snippets-helper/)| Replace `CodeSnippet` component with `get-code-snippet` helper when updating `ember-code-snippet` to v3. | |
 
 ## Contributing
 

--- a/src/transforms/ember-code-snippets-helper/index.ts
+++ b/src/transforms/ember-code-snippets-helper/index.ts
@@ -1,0 +1,109 @@
+import type { FileInfo } from "jscodeshift";
+import type { TransformPluginBuilder, Syntax } from "ember-template-recast";
+import { transform } from "ember-template-recast";
+import type { ASTv1 as AST } from "@glimmer/syntax";
+
+export const parser = "ts";
+const SUPPORTED_CODE_SNIPPET_PATH_TYPES = [
+  "StringLiteral",
+  "SubExpression",
+  "PathExpression",
+];
+
+function getCodeSnippetHelper({
+  builders,
+  snippetPath,
+}: {
+  builders: Syntax["builders"];
+  snippetPath?: AST.Expression;
+}): AST.BlockStatement | undefined {
+  if (
+    !snippetPath ||
+    !SUPPORTED_CODE_SNIPPET_PATH_TYPES.includes(snippetPath.type)
+  ) {
+    return;
+  }
+
+  const typecastSnippetPath = snippetPath as AST.Expression;
+
+  return builders.block(
+    builders.path("let"),
+    [builders.sexpr(builders.path("get-code-snippet"), [typecastSnippetPath])],
+    builders.hash(),
+    builders.program(
+      [
+        builders.text("\n"),
+        builders.element("pre", {
+          attrs: [
+            builders.attr(
+              "class",
+              builders.mustache(builders.path("snippet.language")),
+            ),
+          ],
+          children: [builders.mustache(builders.path("snippet.source"))],
+        }),
+        builders.text("\n"),
+      ],
+      ["snippet"],
+    ),
+  );
+}
+
+const replaceWithSyntaxTransformPlugin: TransformPluginBuilder = (env) => {
+  const {
+    syntax: { builders },
+  } = env;
+
+  return {
+    MustacheStatement(node) {
+      if (
+        node.path.type === "PathExpression" &&
+        node.path.original === "code-snippet"
+      ) {
+        const namePair = node.hash.pairs.find((pair) => pair.key === "name");
+        const snippetPath = namePair?.value;
+
+        return getCodeSnippetHelper({ snippetPath, builders });
+      }
+    },
+    ElementNode(node) {
+      if (node.tag === "CodeSnippet") {
+        const nameAttr = node.attributes.find((attr) => attr.name === "@name");
+        const snippetPath = nameAttr?.value;
+
+        if (!snippetPath) {
+          return;
+        }
+
+        switch (snippetPath?.type) {
+          case "MustacheStatement":
+            if (snippetPath.path.type === "PathExpression") {
+              if (
+                snippetPath.path.original.startsWith("this") ||
+                snippetPath.path.original.startsWith("@")
+              ) {
+                return getCodeSnippetHelper({
+                  snippetPath: snippetPath.path,
+                  builders,
+                });
+              }
+            }
+
+            return getCodeSnippetHelper({
+              snippetPath: builders.sexpr(snippetPath.path, snippetPath.params),
+              builders,
+            });
+          case "TextNode":
+            return getCodeSnippetHelper({
+              snippetPath: builders.string(snippetPath.chars),
+              builders,
+            });
+        }
+      }
+    },
+  };
+};
+
+export default function transformer(fileInfo: FileInfo) {
+  return transform(fileInfo.source, replaceWithSyntaxTransformPlugin).code;
+}

--- a/src/transforms/ember-code-snippets-helper/tests/fixtures/no-change.input.hbs
+++ b/src/transforms/ember-code-snippets-helper/tests/fixtures/no-change.input.hbs
@@ -1,0 +1,24 @@
+{{#let (get-code-snippet "snippet.hbs") as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet (get-name "snippet.hbs")) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet "snippet.hbs") as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet (get-name "snippet.hbs")) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}

--- a/src/transforms/ember-code-snippets-helper/tests/fixtures/no-change.output.hbs
+++ b/src/transforms/ember-code-snippets-helper/tests/fixtures/no-change.output.hbs
@@ -1,0 +1,24 @@
+{{#let (get-code-snippet "snippet.hbs") as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet (get-name "snippet.hbs")) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet "snippet.hbs") as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet (get-name "snippet.hbs")) as |snippet|}}
+  <pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}

--- a/src/transforms/ember-code-snippets-helper/tests/fixtures/transform.input.hbs
+++ b/src/transforms/ember-code-snippets-helper/tests/fixtures/transform.input.hbs
@@ -1,0 +1,8 @@
+{{code-snippet name='snippet.hbs'}}
+{{code-snippet name=@snippetPath}}
+{{code-snippet name=this.snippetPath}}
+{{code-snippet name=(get-name 'snippet')}}
+<CodeSnippet @name="snippet.hbs"/>
+<CodeSnippet @name={{@snippetPath}}/>
+<CodeSnippet @name={{this.snippetPath}}/>
+<CodeSnippet @name={{get-name 'snippet'}}/>

--- a/src/transforms/ember-code-snippets-helper/tests/fixtures/transform.output.hbs
+++ b/src/transforms/ember-code-snippets-helper/tests/fixtures/transform.output.hbs
@@ -1,0 +1,24 @@
+{{#let (get-code-snippet 'snippet.hbs') as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet (get-name 'snippet')) as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet "snippet.hbs") as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}
+{{#let (get-code-snippet (get-name 'snippet')) as |snippet|}}
+<pre class={{snippet.language}}>{{snippet.source}}</pre>
+{{/let}}

--- a/src/transforms/ember-code-snippets-helper/tests/transform.test.ts
+++ b/src/transforms/ember-code-snippets-helper/tests/transform.test.ts
@@ -1,0 +1,25 @@
+import runTestCases from "#utils/testHelper.js";
+import transform, {
+  parser,
+} from "#transforms/ember-code-snippets-helper/index.js";
+
+const testCases = [
+  {
+    name: "should handle old code snippet component usage",
+    input: "transform.input.hbs",
+    output: "transform.output.hbs",
+  },
+  {
+    name: "should not do anything if there is no old code snippet component usage",
+    input: "no-change.input.hbs",
+    output: "no-change.output.hbs",
+  },
+];
+
+runTestCases(
+  "ember-code-snippets-helper",
+  __dirname,
+  testCases,
+  transform,
+  parser,
+);


### PR DESCRIPTION
* `ember-code-snippets` needs to be updated to v3 to be compatible with Ember v5
* v3 replaced the `CodeSnippet` component with a `get-code-snippet` helper, so it'll be helpful to have a codemod for it