### PR TITLE
Remove whitespace inserted by `ember-code-snippets-helper` transform

### DIFF
--- a/.changeset/ready-lions-fly.md
+++ b/.changeset/ready-lions-fly.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Remove whitespace inserted by `ember-code-snippets-helper` transform

--- a/src/transforms/ember-code-snippets-helper/index.ts
+++ b/src/transforms/ember-code-snippets-helper/index.ts
@@ -32,7 +32,6 @@ function getCodeSnippetHelper({
     builders.hash(),
     builders.program(
       [
-        builders.text("\n"),
         builders.element("pre", {
           attrs: [
             builders.attr(
@@ -42,7 +41,6 @@ function getCodeSnippetHelper({
           ],
           children: [builders.mustache(builders.path("snippet.source"))],
         }),
-        builders.text("\n"),
       ],
       ["snippet"],
     ),

--- a/src/transforms/ember-code-snippets-helper/tests/fixtures/transform.output.hbs
+++ b/src/transforms/ember-code-snippets-helper/tests/fixtures/transform.output.hbs
@@ -1,24 +1,8 @@
-{{#let (get-code-snippet 'snippet.hbs') as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
-{{#let (get-code-snippet @snippetPath) as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
-{{#let (get-code-snippet this.snippetPath) as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
-{{#let (get-code-snippet (get-name 'snippet')) as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
-{{#let (get-code-snippet "snippet.hbs") as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
-{{#let (get-code-snippet @snippetPath) as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
-{{#let (get-code-snippet this.snippetPath) as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
-{{#let (get-code-snippet (get-name 'snippet')) as |snippet|}}
-<pre class={{snippet.language}}>{{snippet.source}}</pre>
-{{/let}}
+{{#let (get-code-snippet 'snippet.hbs') as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}
+{{#let (get-code-snippet (get-name 'snippet')) as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}
+{{#let (get-code-snippet "snippet.hbs") as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}
+{{#let (get-code-snippet @snippetPath) as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}
+{{#let (get-code-snippet this.snippetPath) as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}
+{{#let (get-code-snippet (get-name 'snippet')) as |snippet|}}<pre class={{snippet.language}}>{{snippet.source}}</pre>{{/let}}


### PR DESCRIPTION
* This was strangely causing issues with the ember-template-lint autofixer