### PR TITLE
MCPA-18487: Add `replace-proxy-hack-with-decorator` transform

### DIFF
--- a/.changeset/green-hairs-listen.md
+++ b/.changeset/green-hairs-listen.md
@@ -1,0 +1,5 @@
+---
+"@ciena-org/ember-codemods": patch
+---
+
+Add `replace-proxy-hack-with-decorator` transform

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npx @ciena-org/ember-codemods $TRANSFORM path/of/files/ or/some**/*glob.js
 | --------- | ----------- | --------------- |
 | [revert-computed-macro](./src/transforms/revert-computed-macro/)| Replace `computed` from `ember-macro-helpers` with `@ember/object` instead. | <ul><li>Will add variable even if not used from function before. Can just remove as need be (or PR fix), was not a common occurence in my code to have unused dependency</li></ul> |
 | [ember-code-snippets-helper](./src/transforms/ember-code-snippets-helper/)| Replace `CodeSnippet` component with `get-code-snippet` helper when updating `ember-code-snippet` to v3. | |
+| [replace-proxy-hack-with-decorator](./src/transforms/replace-proxy-hack-with-decorator//)| Replace internal `proxyAttr`, `proxyBelongsTo`, and `proxyHasMany` macros with a `expectationProxy` class decorator. | This only works with models that aren't native classes, but I think it should be okay since the only models using these macros are following the classic syntax. |
 
 ## Contributing
 

--- a/src/transforms/replace-proxy-hack-with-decorator/index.ts
+++ b/src/transforms/replace-proxy-hack-with-decorator/index.ts
@@ -1,0 +1,124 @@
+import { addImport } from "#utils/transforms/import.js";
+import type { API, Collection, FileInfo } from "jscodeshift";
+import type { Options } from "jscodeshift";
+
+export const parser = "ts";
+
+function handleProxyHack({
+  api,
+  api: { jscodeshift: j },
+  root,
+  proxyMacro,
+  actualMacro,
+}: {
+  api: API;
+  root: Collection;
+  proxyMacro: "proxyAttr" | "proxyBelongsTo" | "proxyHasMany";
+  actualMacro: string;
+}): boolean {
+  const proxyRelationships = root
+    .find(j.Identifier)
+    .filter((p) => {
+      return p.value.name === proxyMacro;
+    })
+    .closest(j.CallExpression)
+    .forEach((p) => {
+      p.value.callee = j.identifier(actualMacro);
+    });
+
+  if (proxyRelationships.length > 0) {
+    addImport({
+      api,
+      root,
+      source: "@ember-data/model",
+      specifier: actualMacro,
+    });
+    return true;
+  }
+
+  return false;
+}
+
+function addProxyDecorator({
+  api,
+  api: { jscodeshift: j },
+  root,
+}: {
+  api: API;
+  root: Collection;
+}) {
+  addImport({
+    api,
+    root,
+    source: "@ice/data/utils/decorators/model",
+    specifier: "expectationProxy",
+  });
+
+  const exportedModelObject = root
+    .find(j.ExportDefaultDeclaration)
+    .find(j.CallExpression)
+    .filter(
+      (p) =>
+        p.value.callee.type === "MemberExpression" &&
+        p.value.callee.object.type === "Identifier" &&
+        p.value.callee.object.name === "Model",
+    );
+
+  if (exportedModelObject.length === 1) {
+    exportedModelObject.replaceWith(
+      j.callExpression(
+        j.callExpression(j.identifier("expectationProxy"), []),
+        exportedModelObject.nodes(),
+      ),
+    );
+    return;
+  }
+}
+
+export default function transformer(
+  fileInfo: FileInfo,
+  api: API,
+  options: Options,
+) {
+  const j = api.jscodeshift;
+
+  // Get the root of the current file's AST
+  const root = j(fileInfo.source, options);
+
+  let hasProxyHack = handleProxyHack({
+    api,
+    root,
+    proxyMacro: "proxyAttr",
+    actualMacro: "attr",
+  });
+
+  hasProxyHack = handleProxyHack({
+    api,
+    root,
+    proxyMacro: "proxyBelongsTo",
+    actualMacro: "belongsTo",
+  });
+
+  hasProxyHack = handleProxyHack({
+    api,
+    root,
+    proxyMacro: "proxyHasMany",
+    actualMacro: "hasMany",
+  });
+
+  if (hasProxyHack) {
+    addProxyDecorator({ api, root });
+
+    const proxyMacroImport = root
+      .find(j.ImportDeclaration)
+      .filter(
+        (p) =>
+          p.value.source.value === "@ice/data/utils/macros/ember-data/proxy",
+      );
+
+    proxyMacroImport.remove();
+  }
+
+  // Return the modified code
+  return root.toSource({ quote: "single", objectCurlySpacing: false });
+}

--- a/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/mixed.input.js
+++ b/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/mixed.input.js
@@ -1,0 +1,16 @@
+import Model, {attr, hasMany, belongsTo} from '@ember-data/model';
+import {
+  proxyAttr,
+  proxyHasMany,
+  proxyBelongsTo,
+} from '@ice/data/utils/macros/ember-data/proxy';
+
+export default Model.extends({
+  foo: proxyAttr('string'),
+  bar: proxyAttr(),
+  baz: attr(),
+  fooHasMany: proxyHasMany('foo', { async: true, inverse: null }),
+  bazHasMany: hasMany('baz', {async: true, inverse: null}),
+  barBelongsTo: proxyBelongsTo('foo', { async: true, inverse: null }),
+  bazBelongsTo: belongsTo('baz', {async: true, inverse: null}),
+});

--- a/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/mixed.output.js
+++ b/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/mixed.output.js
@@ -1,0 +1,12 @@
+import Model, {attr, hasMany, belongsTo} from '@ember-data/model';
+import {expectationProxy} from '@ice/data/utils/decorators/model';
+
+export default expectationProxy()(Model.extends({
+  foo: attr('string'),
+  bar: attr(),
+  baz: attr(),
+  fooHasMany: hasMany('foo', { async: true, inverse: null }),
+  bazHasMany: hasMany('baz', {async: true, inverse: null}),
+  barBelongsTo: belongsTo('foo', { async: true, inverse: null }),
+  bazBelongsTo: belongsTo('baz', {async: true, inverse: null}),
+}));

--- a/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/no-change.input.js
+++ b/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/no-change.input.js
@@ -1,0 +1,11 @@
+import Model, {attr, hasMany, belongsTo} from '@ember-data/model';
+
+export default Model.extends({
+  foo: attr('string'),
+  bar: attr(),
+  baz: attr(),
+  fooHasMany: hasMany('foo', { async: true, inverse: null }),
+  bazHasMany: hasMany('baz', {async: true, inverse: null}),
+  barBelongsTo: belongsTo('foo', { async: true, inverse: null }),
+  bazBelongsTo: belongsTo('baz', {async: true, inverse: null}),
+});

--- a/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/no-change.output.js
+++ b/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/no-change.output.js
@@ -1,0 +1,11 @@
+import Model, {attr, hasMany, belongsTo} from '@ember-data/model';
+
+export default Model.extends({
+  foo: attr('string'),
+  bar: attr(),
+  baz: attr(),
+  fooHasMany: hasMany('foo', { async: true, inverse: null }),
+  bazHasMany: hasMany('baz', {async: true, inverse: null}),
+  barBelongsTo: belongsTo('foo', { async: true, inverse: null }),
+  bazBelongsTo: belongsTo('baz', {async: true, inverse: null}),
+});

--- a/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/only-proxy.input.js
+++ b/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/only-proxy.input.js
@@ -1,0 +1,13 @@
+import Model from '@ember-data/model';
+import {
+  proxyAttr,
+  proxyHasMany,
+  proxyBelongsTo,
+} from '@ice/data/utils/macros/ember-data/proxy';
+
+export default Model.extends({
+  foo: proxyAttr('string'),
+  bar: proxyAttr(),
+  fooHasMany: proxyHasMany('foo', { async: true, inverse: null }),
+  barBelongsTo: proxyBelongsTo('foo', { async: true, inverse: null }),
+});

--- a/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/only-proxy.output.js
+++ b/src/transforms/replace-proxy-hack-with-decorator/tests/fixtures/only-proxy.output.js
@@ -1,0 +1,9 @@
+import Model, {attr, belongsTo, hasMany} from '@ember-data/model';
+import {expectationProxy} from '@ice/data/utils/decorators/model';
+
+export default expectationProxy()(Model.extends({
+  foo: attr('string'),
+  bar: attr(),
+  fooHasMany: hasMany('foo', { async: true, inverse: null }),
+  barBelongsTo: belongsTo('foo', { async: true, inverse: null }),
+}));

--- a/src/transforms/replace-proxy-hack-with-decorator/tests/transform.test.ts
+++ b/src/transforms/replace-proxy-hack-with-decorator/tests/transform.test.ts
@@ -1,0 +1,30 @@
+import runTestCases from "#utils/testHelper.js";
+import transform, {
+  parser,
+} from "#transforms/replace-proxy-hack-with-decorator/index.js";
+
+const testCases = [
+  {
+    name: "should handle only proxy properties",
+    input: "only-proxy.input.js",
+    output: "only-proxy.output.js",
+  },
+  {
+    name: "should handle mixed properties",
+    input: "mixed.input.js",
+    output: "mixed.output.js",
+  },
+  {
+    name: "should not do anything if no proxy hacks are being used",
+    input: "no-change.input.js",
+    output: "no-change.output.js",
+  },
+];
+
+runTestCases(
+  "replace-proxy-hack-with-decorator",
+  __dirname,
+  testCases,
+  transform,
+  parser,
+);

--- a/src/utils/transforms/import.ts
+++ b/src/utils/transforms/import.ts
@@ -1,0 +1,80 @@
+import type { API, Collection, ImportDeclaration } from "jscodeshift";
+
+export function addImportDeclaration({
+  api: { jscodeshift: j },
+  root,
+  declaration,
+}: {
+  api: API;
+  root: Collection;
+  declaration: ImportDeclaration;
+}) {
+  const imports = root.find(j.ImportDeclaration);
+  if (imports.length > 0) {
+    // Add after the last import statement
+    imports.at(-1).insertAfter(declaration);
+  } else {
+    // Add at the top of the file
+    const program = root.find(j.Program).nodes()[0];
+    program.body = [declaration, ...program.body];
+  }
+}
+
+export function addImportSpecifier({
+  api: { jscodeshift: j },
+  declaration,
+  specifier,
+}: {
+  api: API;
+  declaration: Collection;
+  specifier: string;
+}) {
+  if (
+    declaration
+      .find(j.ImportSpecifier)
+      .filter((p) => p.value.imported.name === specifier).length === 0
+  ) {
+    const { specifiers = [] } = declaration.nodes()[0];
+
+    declaration.at(0).forEach((p) => {
+      p.value.specifiers = specifiers.concat([
+        j.importSpecifier(j.identifier(specifier)),
+      ]);
+    });
+  }
+}
+
+export function addImport({
+  api,
+  api: { jscodeshift: j },
+  root,
+  source,
+  specifier,
+}: {
+  api: API;
+  root: Collection;
+  source: string;
+  specifier: string;
+}) {
+  const declaration = root
+    .find(j.ImportDeclaration)
+    .filter((p) => p.value.source.value === source);
+  const importSpecifier = j.importSpecifier(j.identifier(specifier));
+
+  if (declaration.length === 0) {
+    addImportDeclaration({
+      api,
+      root,
+      declaration: j.importDeclaration(
+        [importSpecifier],
+        j.stringLiteral(source),
+      ),
+    });
+  } else {
+    addImportSpecifier({
+      api,
+      declaration,
+      specifier,
+    });
+  }
+}


### PR DESCRIPTION
* This transform replaces the internal `proxyAttr`, `proxyBelongsTo`, and `proxyHasMany` macros with a `expectationProxy` class decorator.
* This only works with models that aren't native classes, but I think it should be okay since the only models using these macros are following the classic syntax.